### PR TITLE
Fix puppeteerPath

### DIFF
--- a/lib/js/pdf-generator.js
+++ b/lib/js/pdf-generator.js
@@ -6,7 +6,7 @@ const createPdf = async () => {
 
     let browser;
     try {
-        browser = await dhalang.launchPuppeteer(configuration.puppeteerModulePath);
+        browser = await dhalang.launchPuppeteer(configuration.puppeteerPath);
         const page = await browser.newPage();
         await page.goto(configuration.webPageUrl, dhalang.getNavigationParameters());
         await page.waitFor(250);

--- a/lib/js/screenshot-generator.js
+++ b/lib/js/screenshot-generator.js
@@ -6,7 +6,7 @@ const createPdf = async () => {
 
     let browser;
     try {
-        browser = await dhalang.launchPuppeteer(configuration.puppeteerModulePath);
+        browser = await dhalang.launchPuppeteer(configuration.puppeteerPath);
         const page = await browser.newPage();
         await page.goto(configuration.webPageUrl, dhalang.getNavigationParameters());
         await page.waitFor(250);


### PR DESCRIPTION
I believe you have a typo when passing the node_modules path to launch puppeteer. Without this change I would get the error `The "path" argument must be of type string. Received type undefined`  on line 38 of dhalang.js:

```
const puppeteer = require('puppeteer');
```

It was really throwing me for a loop because when I vendorized the gem everything worked fine, but when I used it normally through bundler I would get that error.  