### PR TITLE
Raise exception on error from puppeteer

### DIFF
--- a/lib/Dhalang.rb
+++ b/lib/Dhalang.rb
@@ -4,9 +4,11 @@ module Dhalang
   require_relative 'Dhalang/version'
   require_relative 'Dhalang/url_utils'
   require_relative 'Dhalang/file_utils'
+  require_relative 'Dhalang/error'
   require_relative 'Dhalang/puppeteer'
   require 'uri'
   require 'tempfile'
   require 'shellwords'
   require 'json'
+  require 'open3'
 end

--- a/lib/Dhalang/error.rb
+++ b/lib/Dhalang/error.rb
@@ -1,0 +1,1 @@
+class DhalangError < StandardError; end

--- a/lib/Dhalang/puppeteer.rb
+++ b/lib/Dhalang/puppeteer.rb
@@ -45,7 +45,17 @@ module Dhalang
         # @param [Object] options               Set of options to use, configurable by the user.
         def self.visit(page_url, script_path, temp_file_path, temp_file_extension, options)
             configuration = create_configuration(page_url, script_path, temp_file_path, temp_file_extension, options)
-            Kernel.system("node #{script_path} #{Shellwords.escape(configuration)}")
+
+            command = "node #{script_path} #{Shellwords.escape(configuration)}"
+
+            Open3.popen2e(command) do |_stdin, stdouterr, wait|
+                return nil if wait.value.success?
+
+                output = stdouterr.read.strip
+                output = nil if output == ''
+                message = output || "Exited with status #{wait.value.exitstatus}"
+                raise DhalangError, message
+            end
         end
 
 

--- a/lib/js/pdf-generator.js
+++ b/lib/js/pdf-generator.js
@@ -19,6 +19,7 @@ const createPdf = async () => {
         });
     } catch (error) {
         console.log(error.message);
+        process.exit(1);
     } finally {
         if (browser) {
             browser.close();

--- a/lib/js/screenshot-generator.js
+++ b/lib/js/screenshot-generator.js
@@ -18,6 +18,7 @@ const createPdf = async () => {
         });
     } catch (error) {
         console.log(error.message);
+        process.exit(1);
     } finally {
         if (browser) {
             browser.close();

--- a/spec/PDF_spec.rb
+++ b/spec/PDF_spec.rb
@@ -29,6 +29,10 @@ describe '#get_from_url' do
       pdf_reader = PDF::Reader.new(create_pdf_file(pdf_binary_content).path)
       expect(pdf_reader.page(1).to_s.include?("Google")).to be true
     end
+
+    it 'should raise DhalangError on unknown domain' do
+      expect { Dhalang::PDF.get_from_url("https://unknown-domain") }.to raise_error(DhalangError, "net::ERR_NAME_NOT_RESOLVED at https://unknown-domain")
+    end
   end
 end
 

--- a/spec/Screenshot_spec.rb
+++ b/spec/Screenshot_spec.rb
@@ -30,6 +30,10 @@ describe '#get_from_url_as_png' do
       file_path = create_image_file(png_binary_content).path
       expect(FastImage.type(file_path)).to be(:png)
     end
+
+    it 'should raise DhalangError on unknown domain' do
+      expect { Dhalang::Screenshot.get_from_url_as_png("https://unknown-domain") }.to raise_error(DhalangError, "net::ERR_NAME_NOT_RESOLVED at https://unknown-domain")
+    end
   end
 end
 

--- a/spec/user_options_spec.rb
+++ b/spec/user_options_spec.rb
@@ -12,12 +12,12 @@ describe 'User option: navigation timeout' do
     context 'when set' do
         it 'is passed as set to the JS script' do
             expectUserOption do |userOptions|
-                expect(userOptions[OPTION_KEY_NAVIGATION_PARAMETERS][OPTION_KEY_NAVIGATION_TIMEOUT]).to be(500)
+                expect(userOptions[OPTION_KEY_NAVIGATION_PARAMETERS][OPTION_KEY_NAVIGATION_TIMEOUT]).to be(12000)
             end
-            Dhalang::Screenshot.get_from_url_as_png("http://www.google.com", {"navigation_timeout": 500})
+            Dhalang::Screenshot.get_from_url_as_png("http://www.google.com", {"navigation_timeout": 12000})
         end
     end
-  
+
     context 'when not set' do
         it 'is passed with a default value of 10000 to the JS script' do
             expectUserOption do |userOptions|
@@ -91,7 +91,7 @@ describe 'User option: http authentication credentials' do
 end
 
 def expectUserOption
-    expect(Kernel).to receive(:system) do |*args|
+    expect(Open3).to receive(:popen2e) do |*args|
         # First get all arguments between first opening and last closing bracket ( i.e. get the JSON ).
         unescapedJson = args[0][/\{(.*)}/,1]
         # Now remove all the slashes, as the JSON is sent as an escaped string.


### PR DESCRIPTION
Example: timeout
```
> Dhalang::PDF.get_from_url("https://www.google.com", navigation_timeout: 1);

DhalangException: Navigation timeout of 1 ms exceeded
from /Users/brianmeta/dev/Dhalang/lib/Dhalang/puppeteer.rb:57:in `block in visit'
```

Example: invalid URL
```
> Dhalang::Screenshot.get_from_url_as_png("https://baddomain");

DhalangException: net::ERR_NAME_NOT_RESOLVED at https://baddomain
from /Users/brianmeta/dev/Dhalang/lib/Dhalang/puppeteer.rb:57:in `block in visit'
```

Example: valid
```
> res = Dhalang::PDF.get_from_url("https://www.google.com");
> res.size
=> 76211
```

Fixes #24