### PR TITLE
Adding AutoHeight

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    Dhalang (0.3.1)
+    Dhalang (0.5.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/Dhalang/puppeteer.rb
+++ b/lib/Dhalang/puppeteer.rb
@@ -10,7 +10,8 @@ module Dhalang
                 userAgent: '',
                 isHeadless: true,
                 viewPort: '',
-                httpAuthenticationCredentials: ''
+                httpAuthenticationCredentials: '',
+                isAutoHeight: false
         }
         private_constant :USER_OPTIONS
 

--- a/lib/js/dhalang.js
+++ b/lib/js/dhalang.js
@@ -18,6 +18,7 @@
  * @property {boolean} isHeadless                   - Indicates if Puppeteer should launch Chromium in headless mode.
  * @property {Object} viewPort                      - The view port to use.
  * @property {Object} httpAuthenticationCredentials - The credentials to use for HTTP authentication.
+ * @property {boolean} isAutoHeight                 - The height is automatically set
  */
 
 /**
@@ -38,7 +39,7 @@ exports.getConfiguration = function () {
 /**
  * Launches Puppeteer and returns its instance.
  * @param {UserOptions} configuration - The configuration to use.
- * @returns {Promise<Object>} 
+ * @returns {Promise<Object>}
  * The launched instance of Puppeteer.
  */
 exports.launchPuppeteer = async function (configuration) {
@@ -71,9 +72,30 @@ exports.configurePage = async function (page, configuration) {
 }
 
 /**
+ * Changes the height the given Puppeteer page.
+ * @param {Object} page - The Puppeteer page to configure.
+ * @param {UserOptions} configuration - The configuration to use.
+ * @returns {Object} - pdfOptions
+ */
+exports.pdfOptionsWithAutoHeight = async function (page, configuration) {
+    const pdfOptions = configuration.pdfOptions
+
+    if (configuration.userOptions.isAutoHeight === true) {
+        const pageHeight = await page.evaluate(() => {
+            return Math.max(document.body.scrollHeight, document.body.offsetHeight);
+        })
+        if (pageHeight) {
+            pdfOptions['height'] = pageHeight + 1 + 'px'
+        }
+    }
+
+    return pdfOptions
+}
+
+/**
  * Extracts the navigation parameters from the configuration in a format that is usable by Puppeteer.
  * @param {Configuration} configuration - The configuration to extract the navigation parameters from.
- * @returns {NavigationParameters} 
+ * @returns {NavigationParameters}
  * The extracted navigation parameters.
  */
 exports.getNavigationParameters = function (configuration) {

--- a/lib/js/pdf-generator.js
+++ b/lib/js/pdf-generator.js
@@ -11,11 +11,12 @@ const createPdf = async () => {
         await dhalang.configurePage(page, configuration.userOptions);
         await page.goto(configuration.webPageUrl, dhalang.getNavigationParameters(configuration));
         await page.waitForTimeout(250);
+        const pdfOptions = await dhalang.pdfOptionsWithAutoHeight(page, configuration)
         await page.pdf({
             ...{
                 path: configuration.tempFilePath
             },
-            ...configuration.pdfOptions
+            ...pdfOptions
         });
     } catch (error) {
         console.error(error.message);


### PR DESCRIPTION
Adding a new attribute `isAutoHeight`
Which when set to true automatically set's the height of the PDF based on the height of the document body.

This is needed to support PDF generation for receipt printers which print on a roll of paper which is automatically cut based on the height of the page.
With this option the width can be set manually based of the width of the roll of paper and the height will be set automatically based on the content.