### PR TITLE
Fix typo: authentication not working

### DIFF
--- a/lib/js/dhalang.js
+++ b/lib/js/dhalang.js
@@ -74,7 +74,7 @@ exports.configure = async function (page, userOptions) {
     }
 
     if (userOptions.httpAuthenticationCredentials !== "") {
-        await page.authenticate(userOptions.authenticationCredentials)
+        await page.authenticate(userOptions.httpAuthenticationCredentials)
     }
 }
 


### PR DESCRIPTION
I noticed the authentication wasn't working and tracked down the issue. It's just a typo. There's no need to update the tests since they don't cover for the JS code.