### PR TITLE
Fix typo in waitUntil option name

### DIFF
--- a/lib/js/dhalang.js
+++ b/lib/js/dhalang.js
@@ -158,7 +158,7 @@ exports.getConfiguredPdfOptions = async function (page, configuration) {
 exports.getNavigationParameters = function (configuration) {
     return {
         timeout: configuration.userOptions.navigationTimeout,
-        waituntil: configuration.userOptions.navigationWaitUntil
+        waitUntil: configuration.userOptions.navigationWaitUntil
     }
 }
 


### PR DESCRIPTION
As [documented here](https://pptr.dev/api/puppeteer.waitforoptions), the wait option spells `waitUntil` instead of `waituntil`.

The typo prevent use of Dhalang's option `navigationWaitUntil` to use [another value](https://pptr.dev/api/puppeteer.puppeteerlifecycleevent) than the default `'load'`.