### PR TITLE
Use URI methods to validate URLs instead of patterns

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: .
   specs:
-    Dhalang (0.7.1)
+    Dhalang (0.7.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    Ascii85 (1.1.0)
+    Ascii85 (1.1.1)
     afm (0.2.2)
-    bigdecimal (3.1.7)
+    bigdecimal (3.1.8)
     diff-lcs (1.5.1)
     fastimage (2.2.7)
     hashery (2.1.2)
@@ -23,15 +23,15 @@ GEM
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.0)
+    rspec-core (3.13.2)
       rspec-support (~> 3.13.0)
-    rspec-expectations (3.13.0)
+    rspec-expectations (3.13.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.0)
+    rspec-mocks (3.13.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-support (3.13.1)
+    rspec-support (3.13.2)
     ruby-rc4 (0.1.5)
     ttfunk (1.8.0)
       bigdecimal (~> 3.1)

--- a/lib/Dhalang/url_utils.rb
+++ b/lib/Dhalang/url_utils.rb
@@ -6,9 +6,10 @@ module Dhalang
         #
         # @param [String] url The url to validate
         def self.validate(url)
-            if (url !~ URI::DEFAULT_PARSER.regexp[:ABS_URI])
-                raise URI::InvalidURIError, 'The given url was invalid, use format http://www.example.com'
-            end
+            parsed = URI.parse(url) # Raise URI::InvalidURIError on invalid URLs
+            return true if parsed.absolute?
+
+            raise URI::InvalidURIError, 'The given url was invalid, use format http://www.example.com'
         end
     end
 end

--- a/lib/Dhalang/version.rb
+++ b/lib/Dhalang/version.rb
@@ -1,3 +1,3 @@
 module Dhalang
-  VERSION = "0.7.1"
+  VERSION = "0.7.2"
 end


### PR DESCRIPTION
Since `uri` 1.0.0 (released last November), the defaut parser for the `URI` module switched to `RFC3986_Parser` ([Changelog](https://github.com/ruby/uri/releases/tag/v1.0.0), [PR](https://github.com/ruby/uri/pull/107)) and RegExp patterns referenced in Dhalang's `UrlUtils` are missing.

This is a proposition to use `URI` methods to validate given URL is an absolute URL. As the programming interface of the `URI` module has been mostly stable for very long time now, this method should be more resilient to future code changes.